### PR TITLE
feat: add user user section

### DIFF
--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -5,6 +5,8 @@ import '../lang/my_localizations.dart';
 import '../widgets/profile/profile_drawer.dart';
 
 class ProfileScreen extends StatelessWidget {
+  final user = auth.FirebaseAuth.instance.currentUser;
+
   void signOut() {
     auth.FirebaseAuth.instance.signOut();
   }
@@ -27,12 +29,62 @@ class ProfileScreen extends StatelessWidget {
           ),
         ],
       ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(10),
-        child: Container(
-          width: double.infinity,
-          child: const Text("Current user placeholder"),
-        ),
+      body: Column(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(10),
+            width: double.infinity,
+            child: Row(
+              children: [
+                Container(
+                  width: 100,
+                  height: 100,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    image: DecorationImage(
+                      fit: BoxFit.fill,
+                      image: NetworkImage(user.photoURL),
+                    ),
+                  ),
+                ),
+                Container(
+                  padding: const EdgeInsets.all(20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        user.displayName,
+                        style: TextStyle(
+                          fontSize: 16,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const Divider(
+            color: Colors.blue,
+            height: 20,
+            thickness: 2,
+            indent: 10,
+            endIndent: 10,
+          ),
+          Expanded(
+            child: GridView.builder(
+              padding: const EdgeInsets.all(20),
+              itemCount: 2,
+              gridDelegate:
+                  SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 2),
+              itemBuilder: (BuildContext context, int index) {
+                return GridTile(
+                  child: const Text("Placeholder for user ads."),
+                );
+              },
+            ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
Added user section to profile_screen. And fixed code skeleton for
user ads.

Small improvment could be done by extracting Divider widget to
stand-alone widget, however I do think that this could lead to over
working the design.

closes #35 